### PR TITLE
Do not check by default code in the `test` dir for dialyzer and xref

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,6 @@ all() -> [dialyzer].
 | `dialyzer_warnings` | The active warnings for _diaylzer_ | `[error_handling, race_conditions, unmatched_returns, unknown]` |
 | `plts` | The list of plt files for _dialyzer_ | `filelib:wildcard("your_app/*.plt")` |
 | `elvis_config` | Config file for _elvis_ | `"your_app/elvis.config"` |
-| `xref_config` | Config options for _xref_ | `#{dirs => [filename:join(BaseDir, "ebin"), filename:join(BaseDir, "test")], xref_defaults => [{verbose, true}, {recurse, true}, {builtins, true}]}` |
+| `xref_config` | Config options for _xref_ | `#{dirs => [filename:join(BaseDir, "ebin")], xref_defaults => [{verbose, true}, {recurse, true}, {builtins, true}]}` |
 | `xref_checks` | List of checks for _xref_ | `[ undefined_function_calls, locals_not_used, deprecated_function_calls]` |
-| `dirs` | List of folders to check with _xref_ and _dialyzer_ | `["ebin", "test"]` |
+| `dirs` | List of folders to check with _xref_ and _dialyzer_ | `["ebin"]` |

--- a/src/ktn_meta_SUITE.erl
+++ b/src/ktn_meta_SUITE.erl
@@ -141,7 +141,7 @@ dirs(Config) ->
   BaseDir = base_dir(Config),
   Dirs =
     case test_server:lookup_config(dirs, Config) of
-      undefined -> ["ebin", "test"];
+      undefined -> ["ebin"];
       Directories -> Directories
     end,
   [filename:join(BaseDir, Dir) || Dir <- Dirs].


### PR DESCRIPTION
* Users of dialyzer and xref usually prefer checking code supposed to
  be shipped - not test code;

* Modules in the `test` dir may contain invalid code - e.g. calls to
  undefined functions - on purpose.

----

I did not change the elvis dirs as I am not sure about best practices there e.g. it may make sense to enforce max line length on tests too.