### PR TITLE
Write end_per_suite following OTP doc on init_per_suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ To include the suite in your project, you only need to invoke its functions from
 -include_lib("mixer/include/mixer.hrl").
 -mixin([ktn_meta_SUITE]).
 
--export([init_per_suite/1]).
+-export([init_per_suite/1, end_per_suite/1]).
 
 init_per_suite(Config) -> [{application, your_app} | Config].
+end_per_suite(_) -> ok.
 ```
 
 Of course, you can choose what functions to include, for example if you want `dialyzer` but not `elvis` nor `xref` you can do…

--- a/test/ktn_meta_suite_SUITE.erl
+++ b/test/ktn_meta_suite_SUITE.erl
@@ -9,10 +9,14 @@
           ]
         }]).
 
--export([init_per_suite/1]).
+-export([init_per_suite/1, end_per_suite/1]).
 
 -type config() :: [{atom(), term()}].
 
 -spec init_per_suite(config()) -> config().
 init_per_suite(Config) ->
   [{application, katana_test}| Config].
+
+-spec end_per_suite(config()) -> term() | {save_config, config()}.
+end_per_suite(_) ->
+  ok.


### PR DESCRIPTION
Review triggered by [a change in
sumo_rest](https://github.com/inaka/sumo_rest/commit/0a0b184b1669ad1b514a86561aeeef5e5f1f0884#diff-78e0a5552797099bbbdef4edb1a55a63R12).

If init is defined, end must be too. Refs
[1](https://github.com/erlang/otp/blob/OTP-19.3.4/lib/common_test/doc/src/write_test_chapter.xml#L88)
[2](https://github.com/erlang/otp/blob/OTP-19.3.4/lib/common_test/doc/src/common_test_app.xml#L227-L229).

Type spec of end function is
[relaxed](https://github.com/erlang/otp/blob/OTP-19.3.4/lib/common_test/doc/src/common_test_app.xml#L251-L257),
and examplary return value is
[`ok`](https://github.com/erlang/otp/blob/OTP-19.3.4/lib/common_test/doc/src/example_chapter.xml#L95).