### PR TITLE
Remove unknown from the list of dialyzer warnings

### DIFF
--- a/src/ktn_meta_SUITE.erl
+++ b/src/ktn_meta_SUITE.erl
@@ -60,7 +60,6 @@ dialyzer(Config) ->
       undefined -> [ error_handling
                    , race_conditions
                    , unmatched_returns
-                   , unknown
                    ];
       Ws -> Ws
     end,


### PR DESCRIPTION
I fixed #38 / #48, but I'm still inclined to also remove `unknown` from the default list of dialyzer warnings.
With `unknown` present, the dialyzer-related test case will always fail if you created the PLT running `rebar3 dialyzer` (i.e. on the default profile, which is what most people tend to do).
Leaving `unknown` in the list, we are effectively forcing our users to run `rebar3 as test dialyzer`, which from some perspective, makes sense but it's still totally unintuitive and certainly not common practice.
So, I think we should remove `unknown` from the list of dialyzer warnings and add it manually to our projects. There, we would recommend using `rebar3 as test do compile, dialyzer, ct` in the README.